### PR TITLE
added package name

### DIFF
--- a/src/main/java/brave/webmvc/WebTracingConfiguration.java
+++ b/src/main/java/brave/webmvc/WebTracingConfiguration.java
@@ -42,7 +42,7 @@ public class WebTracingConfiguration extends WebMvcConfigurerAdapter {
   @Bean Reporter<Span> reporter() {
     return new LoggingReporter();
     // uncomment to actually send to zipkin!
-    //return AsyncReporter.builder(sender()).build();
+    //return zipkin.reporter.AsyncReporter.builder(sender()).build();
   }
 
   @Bean Brave brave() {


### PR DESCRIPTION
For those who uncomment line 45 using vi, receive following error: 

    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.5.1:compile (default-compile) on project brave-webmvc-example: Compilation failure
    [ERROR] /private/tmp/brave-webmvc-example/src/main/java/brave/webmvc/WebTracingConfiguration.java:[45,11] error: cannot find symbol
